### PR TITLE
Remove env var from front end

### DIFF
--- a/client/src/Login.jsx
+++ b/client/src/Login.jsx
@@ -43,9 +43,9 @@ export default function Login() {
             password: password
         };
 
-        const API_URL = process.env.REACT_APP_API_URL;
+        
 
-        fetch(API_URL + '/api/users/login/', {
+        fetch('/api/users/login/', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/client/src/SignUp.jsx
+++ b/client/src/SignUp.jsx
@@ -46,9 +46,7 @@ export default function SignUp() {
       password: password
     };
 
-    const API_URL = process.env.REACT_APP_API_URL;
-
-    fetch(API_URL + '/api/users/register/', {
+    fetch('/api/users/register/', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
package.json has a proxy url to localhost:9000 for local dev so requests to paths will automatically route to the backend service.

in prod we build the client and host static. Traffic is pretty low across the apps so we use this just to save on devops lift until we bring someone in to setup a more permanent CI/CD solution.